### PR TITLE
Release/1.0.1

### DIFF
--- a/examples/complete/terragrunt.hcl
+++ b/examples/complete/terragrunt.hcl
@@ -75,7 +75,7 @@ generate "providers" {
     required_providers {
       aws = {
         source  = "hashicorp/aws"
-        version = "~> 4"
+        version = ">= 5.45.0"
       }
       local = {
         source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 5.45.0"
     }
   }
 }


### PR DESCRIPTION
## what

Revise the **hashicorp/aws** provider version to `">= 5.45.0`

## why

The Pessimistic Version Constraint `~> 4.0` was causing consuming projects to fail to resolve dependencies because most projects are explicitly on 5.x now.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the AWS provider version requirement to ensure access to the latest features and improvements.
  
- **Bug Fixes**
	- Enhanced compatibility with the AWS provider by specifying a minimum version, which may resolve issues related to older configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->